### PR TITLE
Improved URL handling, changed default browser and variable to disable default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ different mappings to those provided by default.
 * `<Plug>(open-url-wiki-search)`
 * `<Plug>(open-url-google-search)`
 
+### VIM Variables :
+* `g:open_url_browser_default` changes default browser (Default: `xdg-open`)
+* `g:open_url_default_mappings` enable/disable default mappings without
+remapping `<Plug>` mappings (Default: `1`)
+
 ### VIM autoload function :
 
 * `open_url#open(a:url)`: Open given url in the default web browser

--- a/autoload/open_url.vim
+++ b/autoload/open_url.vim
@@ -5,7 +5,7 @@ function! open_url#open(url)
   elseif has('mac') || has('macunix') || has('gui_macvim')
     exe 'silent !open "'.url.'"'
   else
-    exe 'silent !'.g:open_url_browser_default url
+    exe 'silent! !'.g:open_url_browser_default.' "'.url.'" &> /dev/null &'
   endif
   redraw!
 endfunction

--- a/plugin/open_url.vim
+++ b/plugin/open_url.vim
@@ -3,13 +3,9 @@ if exists('g:loaded_open_url')
 endif
 let g:loaded_open_url = 1
 
-function! s:SetGlobalOpt(opt, val)
-  if !exists('g:'.a:opt)
-    let g:{a:opt} = a:val
-  endif
-endfunction
-
-call s:SetGlobalOpt('open_url_browser_default', 'xdg-open')
+if !exists('g:open_url_browser_default')
+  let g:open_url_browser_default = 'xdg-open'
+endif
 
 command! -nargs=1 OpenURL call open_url#open(<q-args>)
 command! -nargs=+ -complete=file OpenIn call open_url#open_in(<f-args>)

--- a/plugin/open_url.vim
+++ b/plugin/open_url.vim
@@ -9,7 +9,7 @@ function! s:SetGlobalOpt(opt, val)
   endif
 endfunction
 
-call s:SetGlobalOpt('open_url_browser_default', 'sensible-browser')
+call s:SetGlobalOpt('open_url_browser_default', 'xdg-open')
 
 command! -nargs=1 OpenURL call open_url#open(<q-args>)
 command! -nargs=+ -complete=file OpenIn call open_url#open_in(<f-args>)

--- a/plugin/open_url.vim
+++ b/plugin/open_url.vim
@@ -7,6 +7,10 @@ if !exists('g:open_url_browser_default')
   let g:open_url_browser_default = 'xdg-open'
 endif
 
+if !exists('g:open_url_default_mappings')
+  let g:open_url_default_mappings = 1
+endif
+
 command! -nargs=1 OpenURL call open_url#open(<q-args>)
 command! -nargs=+ -complete=file OpenIn call open_url#open_in(<f-args>)
 command! -nargs=1 -complete=file OpenInChrome OpenIn Google\ Chrome <q-args>
@@ -18,21 +22,23 @@ xnoremap <Plug>(open-url-wiki-search) :<C-U>OpenURL http://en.wikipedia.org/wiki
 nnoremap <Plug>(open-url-google-search) :OpenURL http://www.google.com/search?q=<cword><CR>
 xnoremap <Plug>(open-url-google-search) :<C-U>OpenURL http://www.google.com/search?q=<C-R>=open_url#get_selection()<CR><CR>
 
-if !hasmapto('<Plug>(open-url-browser)', 'n')
-  nmap gB <Plug>(open-url-browser)
-endif
-if !hasmapto('<Plug>(open-url-browser)', 'x')
-  xmap gB <Plug>(open-url-browser)
-endif
-if !hasmapto('<Plug>(open-url-wiki-search)', 'n')
-  nmap gW <Plug>(open-url-wiki-search)
-endif
-if !hasmapto('<Plug>(open-url-wiki-search)', 'x')
-  xmap gW <Plug>(open-url-wiki-search)
-endif
-if !hasmapto('<Plug>(open-url-google-search)', 'n')
-  nmap gG <Plug>(open-url-google-search)
-endif
-if !hasmapto('<Plug>(open-url-google-search)', 'x')
-  xmap gG <Plug>(open-url-google-search)
+if g:open_url_default_mappings
+  if !hasmapto('<Plug>(open-url-browser)', 'n')
+    nmap gB <Plug>(open-url-browser)
+  endif
+  if !hasmapto('<Plug>(open-url-browser)', 'x')
+    xmap gB <Plug>(open-url-browser)
+  endif
+  if !hasmapto('<Plug>(open-url-wiki-search)', 'n')
+    nmap gW <Plug>(open-url-wiki-search)
+  endif
+  if !hasmapto('<Plug>(open-url-wiki-search)', 'x')
+    xmap gW <Plug>(open-url-wiki-search)
+  endif
+  if !hasmapto('<Plug>(open-url-google-search)', 'n')
+    nmap gG <Plug>(open-url-google-search)
+  endif
+  if !hasmapto('<Plug>(open-url-google-search)', 'x')
+    xmap gG <Plug>(open-url-google-search)
+  endif
 endif

--- a/plugin/open_url.vim
+++ b/plugin/open_url.vim
@@ -3,13 +3,14 @@ if exists('g:loaded_open_url')
 endif
 let g:loaded_open_url = 1
 
-if !exists('g:open_url_browser_default')
-  let g:open_url_browser_default = 'xdg-open'
-endif
+function! s:SetGlobalOpt(opt, val)
+  if !exists('g:'.a:opt)
+    let g:{a:opt} = a:val
+  endif
+endfunction
 
-if !exists('g:open_url_default_mappings')
-  let g:open_url_default_mappings = 1
-endif
+call s:SetGlobalOpt('open_url_browser_default', 'xdg-open')
+call s:SetGlobalOpt('open_url_default_mappings', '1')
 
 command! -nargs=1 OpenURL call open_url#open(<q-args>)
 command! -nargs=+ -complete=file OpenIn call open_url#open_in(<f-args>)


### PR DESCRIPTION
* Some URL (e.g. `http://www.egr.unlv.edu/~ed/assembly64.pdf#page=21&zoom=auto,-304,543`) would be opened partially (`http://www.egr.unlv.edu/~ed/assembly64.pdf#page=21`)
* `xdg-open` is currently most commonly used for opening various files with user default applications
* Added variable allowing to disable default mappings completely
* In README was no mention about available variables