### PR TITLE
Add .gitignore with doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Hello! Just a minor addition here, which prevents git from picking up the automatically generated `doc/tags` ~~directory~~ uhh, file.